### PR TITLE
fix cancel icon import

### DIFF
--- a/src/components/home/welcomeBubble/WelcomeBubble.tsx
+++ b/src/components/home/welcomeBubble/WelcomeBubble.tsx
@@ -1,4 +1,4 @@
-import Cancel from '@material-ui/icons/cancel';
+import CancelIcon from '@material-ui/icons/cancel';
 import '../../../assets/stylesheets/home/WelcomeBubble.scss';
 
 interface WelcomeBubbleProps {
@@ -10,7 +10,7 @@ interface WelcomeBubbleProps {
 const WelcomeBubble = ({ welcomeMessage, closeWelcomeMessage, handleChangeIcon }: WelcomeBubbleProps) => {
   return (
     welcomeMessage && <>
-      <Cancel
+      <CancelIcon
         className='cancel'
         id='cancel'
         fontSize='small'


### PR DESCRIPTION
The 'Cancel' import for cancel Icon from Material UI has been changed to 'CancelIcon'

<img width="475" alt="image" src="https://github.com/Simhanischal/Mini-ChatGPT/assets/33859648/3e2f0525-34cf-4c63-855e-418221cbad46">
