### PR TITLE
Add tests for components

### DIFF
--- a/jestconfig.json
+++ b/jestconfig.json
@@ -9,7 +9,7 @@
     "testRegex": "(/tests/.*|(\\.|/)(test|spec))\\.tsx?$",
     "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"],
     "testEnvironment": "jsdom",
-    "collectCoverage": true,
+    "collectCoverage": false,
     "collectCoverageFrom": ["src/**/*.tsx"],
     "coverageDirectory": "target/reports/coverage",
     "coverageReporters": ["html", "lcov", "cobertura", "text-summary"]

--- a/src/components/chat/chatBubble/ChatBubble.tsx
+++ b/src/components/chat/chatBubble/ChatBubble.tsx
@@ -19,12 +19,12 @@ const ChatBubble = (props: ChatBubbleProps) => {
 
   return (
     <div className={`${classNameText}-bubble-div`}>
-      {isBotBubble && <img alt="Chat Avatar" className="chat-avatar" src={Image} />}
-      <div className={`${classNameText}-bubble`} id="bubble">
+      {isBotBubble && <img alt="Chat Avatar" data-testid="bubble-avatar" className="chat-avatar" src={Image} />}
+      <div className={`${classNameText}-bubble`} data-testid="bubble-message" id="bubble">
         {message}
       </div>
       <br />
-      <div className={`${classNameText}-date-time`} id="datetime">
+      <div className={`${classNameText}-date-time`} data-testid="bubble-datetime" id="datetime">
         {datetime}
       </div>
       <br />

--- a/src/components/chat/chatInput/ChatInput.tsx
+++ b/src/components/chat/chatInput/ChatInput.tsx
@@ -5,7 +5,7 @@ import '../../../assets/stylesheets/chat/chatInput.scss';
 
 interface ChatInputProps {
   input: string;
-  inputRef: React.RefObject<HTMLTextAreaElement>;
+  inputRef?: React.RefObject<HTMLTextAreaElement>;
   handleInputChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
   handleEnter: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void;
   handleSend: () => void;
@@ -19,13 +19,14 @@ const ChatInput = (props: ChatInputProps) => {
     //this case is being handled because of keyboard popping up
     //in mobile devices as soon as the text area is focused
     if (window.screen.width > 500)
-      inputRef.current?.focus();
+      inputRef?.current?.focus();
   });
 
   return (
     <div className="chat-input-container">
       <textarea
         className="chat-text-area"
+        data-testid="chat-text-area"
         placeholder="Ask me anything!"
         value={input}
         ref={inputRef}

--- a/src/components/chat/chatMessages/ChatMessages.tsx
+++ b/src/components/chat/chatMessages/ChatMessages.tsx
@@ -1,7 +1,7 @@
 import "../../../assets/stylesheets/chat/chatMessages.scss";
 
 interface ChatMessagesProps {
-  windowEndRef: React.RefObject<HTMLDivElement>;
+  windowEndRef?: React.RefObject<HTMLDivElement>;
   children: React.ReactNode;
 }
 

--- a/src/components/chat/typingIndicator/TypingIndicator.tsx
+++ b/src/components/chat/typingIndicator/TypingIndicator.tsx
@@ -9,7 +9,7 @@ const TypingIndicator = ({ typingIndicator }: TypingIndicatorProps) => {
   let display;
   if (typingIndicator) {
     display = (
-      <div className="typing-indicator-container">
+      <div className="typing-indicator-container" data-testid="typing-indicator">
         <img className="chatAvatar" alt="Avatar" src={Image} />
         <span id="text">GPT is typing.....</span>
       </div>

--- a/src/components/home/backupAlert/BackupAlert.tsx
+++ b/src/components/home/backupAlert/BackupAlert.tsx
@@ -28,10 +28,10 @@ const BackupAlert = ({ openAlert, handleRestore, handleNewConvo }: BackupAlertPr
         </DialogContentText>
       </DialogContent>
       <DialogActions>
-        <Button id="restore-button" onClick={handleRestore}>
+        <Button id="restore-button" data-testid="restore-button" onClick={handleRestore}>
           Yes, restore!
         </Button>
-        <Button id="new-convo-button" onClick={handleNewConvo}>
+        <Button id="new-convo-button" data-testid="new-convo-button" onClick={handleNewConvo}>
           No, start a new conversation!
         </Button>
       </DialogActions>

--- a/src/components/home/welcomeCircle/WelcomeCircle.tsx
+++ b/src/components/home/welcomeCircle/WelcomeCircle.tsx
@@ -25,7 +25,7 @@ const WelcomeCircle = ({changeIcon, welcomeMessage, handleChangeIcon, image, wid
       <>
         &nbsp;&nbsp;
         <Badge badgeContent={1} overlap="circular" color="error">
-          <button className="avatar" onClick={handleChangeIcon}>
+          <button className="avatar" data-testid="avatar-button" onClick={handleChangeIcon}>
             <img alt="avatar" data-testid="welcome-circle-image" src={image} width={width} />
           </button>
         </Badge> 
@@ -33,7 +33,7 @@ const WelcomeCircle = ({changeIcon, welcomeMessage, handleChangeIcon, image, wid
     );
   } else{
     display = (
-      <button className="avatar" onClick={handleChangeIcon}>
+      <button className="avatar" data-testid="avatar-button" onClick={handleChangeIcon}>
         { icon }
       </button>
     );

--- a/tests/BackupAlert.test.tsx
+++ b/tests/BackupAlert.test.tsx
@@ -1,0 +1,32 @@
+import {render, screen, fireEvent} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import BackupAlert from '../src/components/home/backupAlert/BackupAlert';
+
+const handleRestore = jest.fn();
+const handleNewConvo = jest.fn();
+
+test('loads and displays backup alert when openAlert is true', async () => {
+  render(<BackupAlert openAlert handleRestore={handleRestore} handleNewConvo={handleNewConvo} />);
+  await screen.findByTestId('sentinelStart');
+  expect(screen.getByTestId('sentinelStart')).toBeVisible();
+});
+
+test('does not display backup alert when openAlert is false', async () => {
+  render(<BackupAlert openAlert={false} handleRestore={handleRestore} handleNewConvo={handleNewConvo} />);
+  expect(screen.queryByTestId('sentinelStart')).toBeNull();
+});
+
+test('calls the event handler upon clicking on restore button', async () => {
+  render(<BackupAlert openAlert handleRestore={handleRestore} handleNewConvo={handleNewConvo} />);
+  await screen.findByTestId('restore-button');
+  fireEvent.click(screen.getByTestId('restore-button'));
+  expect(handleRestore).toHaveBeenCalledTimes(1);
+});
+
+test('calls the event handler upon clicking on backup button', async () => {
+  render(<BackupAlert openAlert handleRestore={handleRestore} handleNewConvo={handleNewConvo} />);
+  await screen.findByTestId('new-convo-button');
+  fireEvent.click(screen.getByTestId('new-convo-button'));
+  expect(handleNewConvo).toHaveBeenCalledTimes(1);
+});
+

--- a/tests/ChatBanner.test.tsx
+++ b/tests/ChatBanner.test.tsx
@@ -1,0 +1,10 @@
+import {render, screen} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ChatBanner from '../src/components/chat/chatBanner/ChatBanner';
+
+test('displays the banner', async () => {
+  render(<ChatBanner />);
+  await screen.findByText('Mini ChatGPT');
+  expect(screen.getByText('Mini ChatGPT')).toBeVisible();
+  expect(screen.getByText('Online')).toBeVisible();
+});

--- a/tests/ChatBubble.test.tsx
+++ b/tests/ChatBubble.test.tsx
@@ -1,0 +1,23 @@
+import {render, screen} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ChatBubble from '../src/components/chat/chatBubble/ChatBubble';
+
+const botMessage = 'I am a bot';
+const userMessage = 'I am an user';
+const botDateTime = '16/09/2023, 20:00:08';
+const userDateTime = '16/09/2023, 20:01:08';
+
+test('displays the avatar when it is a bot chat bubble', async () => {
+  render(<ChatBubble isBotBubble message={botMessage} datetime={botDateTime} />);
+  await screen.findByTestId('bubble-avatar');
+  expect(screen.getByTestId('bubble-avatar')).toBeVisible();
+  expect(screen.getByTestId('bubble-message')).toHaveTextContent(botMessage);
+  expect(screen.getByTestId('bubble-datetime')).toHaveTextContent(botDateTime);
+});
+
+test('does not display the avatar when it is a user chat bubble', async () => {
+  render(<ChatBubble isBotBubble={false} message={userMessage} datetime={userDateTime} />);
+  expect(screen.queryByTestId('bubble-avatar')).toBeNull();
+  expect(screen.getByTestId('bubble-message')).toHaveTextContent(userMessage);
+  expect(screen.getByTestId('bubble-datetime')).toHaveTextContent(userDateTime);
+});

--- a/tests/ChatInput.test.tsx
+++ b/tests/ChatInput.test.tsx
@@ -1,0 +1,33 @@
+import {render, screen, fireEvent} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ChatInput from '../src/components/chat/chatInput/ChatInput';
+
+const input = 'test';
+const handleInputChange = jest.fn();
+const handleEnter = jest.fn();
+const handleSend = jest.fn();
+
+test('displays the send icon when input prop string length is gretaer than 0', async () => {
+  render(<ChatInput input={input} handleInputChange={handleInputChange} handleEnter={handleEnter} handleSend={handleSend} />);
+  await screen.findByTestId('TelegramIcon');
+  expect(screen.getByTestId('TelegramIcon')).toBeVisible();
+});
+
+test('does not display the send icon when input prop string length is 0', async () => {
+  render(<ChatInput input="" handleInputChange={handleInputChange} handleEnter={handleEnter} handleSend={handleSend} />);
+  expect(screen.queryByTestId('TelegramIcon')).toBeNull();
+});
+
+test('calls the event handler upon clicking on send button', async () => {
+  render(<ChatInput input={input} handleInputChange={handleInputChange} handleEnter={handleEnter} handleSend={handleSend} />);
+  await screen.findByTestId('TelegramIcon');
+  fireEvent.click(screen.getByTestId('TelegramIcon'));
+  expect(handleSend).toHaveBeenCalledTimes(1);
+});
+
+test('calls the event handler upon clicking on enter in keyboard', async () => {
+  render(<ChatInput input={input} handleInputChange={handleInputChange} handleEnter={handleEnter} handleSend={handleSend} />);
+  await screen.findByTestId('TelegramIcon');
+  fireEvent.keyDown(screen.getByTestId('chat-text-area'), {key: 'Enter'});
+  expect(handleEnter).toHaveBeenCalledTimes(1);
+});

--- a/tests/ChatMessages.test.tsx
+++ b/tests/ChatMessages.test.tsx
@@ -1,0 +1,11 @@
+import {render, screen} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ChatMessages from '../src/components/chat/chatMessages/ChatMessages';
+
+const children = 'Messages';
+
+test('displays the messages', async () => {
+  render(<ChatMessages children={children} />);
+  await screen.findByText('Messages');
+  expect(screen.getByText('Messages')).toBeVisible();
+});

--- a/tests/TypingIndicator.test.tsx
+++ b/tests/TypingIndicator.test.tsx
@@ -1,0 +1,14 @@
+import {render, screen} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TypingIndicator from '../src/components/chat/typingIndicator/TypingIndicator';
+
+test('displays typing indictor when typingIndicator prop is true', async () => {
+  render(<TypingIndicator typingIndicator />);
+  await screen.findByTestId('typing-indicator');
+  expect(screen.getByTestId('typing-indicator')).toBeVisible();
+});
+
+test('does not display typing indictor when typingIndicator prop is false', async () => {
+  render(<TypingIndicator typingIndicator={false} />);
+  expect(screen.queryByTestId('typing-indicator')).toBeNull();
+});

--- a/tests/WelcomeBubble.test.tsx
+++ b/tests/WelcomeBubble.test.tsx
@@ -1,9 +1,12 @@
-import {render, screen} from '@testing-library/react';
+import {render, screen, fireEvent} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import WelcomeBubble from '../src/components/home/welcomeBubble/WelcomeBubble';
 
+const handleChangeIcon = jest.fn();
+const closeWelcomeMessage = jest.fn();
+
 test('loads and displays welcome bubble if welcomeMessage is true', async () => {
-  render(<WelcomeBubble welcomeMessage={true} closeWelcomeMessage={() => {}} handleChangeIcon={() => {}} />);
+  render(<WelcomeBubble welcomeMessage closeWelcomeMessage={closeWelcomeMessage} handleChangeIcon={handleChangeIcon} />);
   await screen.findByTestId('CancelIcon');
   await screen.findByTestId('bubble');
   expect(screen.getByTestId('CancelIcon')).toBeVisible();
@@ -11,8 +14,24 @@ test('loads and displays welcome bubble if welcomeMessage is true', async () => 
 });
 
 test('does not display welcome bubble if welcomeMessage is false', async () => {
-  render(<WelcomeBubble welcomeMessage={false} closeWelcomeMessage={() => {}} handleChangeIcon={() => {}} />);
+  render(<WelcomeBubble welcomeMessage={false} closeWelcomeMessage={closeWelcomeMessage} handleChangeIcon={handleChangeIcon} />);
   expect(screen.queryByTestId('CancelIcon')).toBeNull();
   expect(screen.queryByTestId('bubble')).toBeNull();
+});
+
+test('calls the event handler upon clicking on cancel icon', async () => {
+  render(<WelcomeBubble welcomeMessage closeWelcomeMessage={closeWelcomeMessage} handleChangeIcon={handleChangeIcon} />);
+  await screen.findByTestId('CancelIcon');
+  await screen.findByTestId('bubble');
+  fireEvent.click(screen.getByTestId('CancelIcon'));
+  expect(closeWelcomeMessage).toHaveBeenCalledTimes(1);
+});
+
+test('calls the event handler upon clicking on the bubble', async () => {
+  render(<WelcomeBubble welcomeMessage closeWelcomeMessage={closeWelcomeMessage} handleChangeIcon={handleChangeIcon} />);
+  await screen.findByTestId('CancelIcon');
+  await screen.findByTestId('bubble');
+  fireEvent.click(screen.getByTestId('bubble'));
+  expect(handleChangeIcon).toHaveBeenCalledTimes(1);
 });
 

--- a/tests/WelcomeCircle.test.tsx
+++ b/tests/WelcomeCircle.test.tsx
@@ -1,22 +1,31 @@
-import {render, screen} from '@testing-library/react';
+import {render, screen, fireEvent} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import WelcomeCircle from '../src/components/home/welcomeCircle/WelcomeCircle';
 
+const handleChangeIcon = jest.fn();
+
 test('loads and displays initial chat icon when welcomeMessage and changeIcon is both false', async () => {
-  render(<WelcomeCircle welcomeMessage={false} changeIcon={false} handleChangeIcon={() => {}} image='' width={200} />);
+  render(<WelcomeCircle welcomeMessage={false} changeIcon={false} handleChangeIcon={handleChangeIcon} image='' width={200} />);
   await screen.findByTestId('QuestionAnswerOutlinedIcon');
   expect(screen.getByTestId('QuestionAnswerOutlinedIcon')).toBeVisible();
 });
 
 test('loads and displays initial clsoe chat icon when welcomeMessage is flase and changeIcon is true', async () => {
-  render(<WelcomeCircle welcomeMessage={false} changeIcon={true} handleChangeIcon={() => {}} image='' width={200} />);
+  render(<WelcomeCircle welcomeMessage={false} changeIcon handleChangeIcon={handleChangeIcon} image='' width={200} />);
   await screen.findByTestId('CloseIcon');
   expect(screen.getByTestId('CloseIcon')).toBeVisible();
 });
 
 test('loads and displays initial chat icon with image when welcomeMessage is true', async () => {
-  render(<WelcomeCircle welcomeMessage={true} changeIcon={false} handleChangeIcon={() => {}} image='' width={200} />);
+  render(<WelcomeCircle welcomeMessage changeIcon={false} handleChangeIcon={handleChangeIcon} image='' width={200} />);
   await screen.findByTestId('welcome-circle-image');
   expect(screen.getByTestId('welcome-circle-image')).toBeVisible();
+});
+
+test('calls the event handler upon clicking on welcome circle', async () => {
+  render(<WelcomeCircle welcomeMessage changeIcon={false} handleChangeIcon={handleChangeIcon} image='' width={200} />);
+  await screen.findByTestId('avatar-button');
+  fireEvent.click(screen.getByTestId('avatar-button'));
+  expect(handleChangeIcon).toHaveBeenCalledTimes(1);
 });
 


### PR DESCRIPTION
- Add tests for components
- Disabled test coverage temporarily as it was getting stuck in an infinite loop while running coverage
- Added data-testid attributes for few elements to use them to find elements while testing

<img width="484" alt="image" src="https://github.com/Simhanischal/Mini-ChatGPT/assets/33859648/1d90aa9b-1538-4f8a-8167-c755872cf409">
