### PR TITLE
Fix scroll issue

### DIFF
--- a/src/components/chat/Chat.tsx
+++ b/src/components/chat/Chat.tsx
@@ -90,7 +90,7 @@ const Chat = ({ messages, setMessages, openWindow, shouldRetrieveBackup }: ChatP
 
   useEffect(() => {
     scrollToBottom();
-  }, [messages, openWindow]);
+  }, [messages, openWindow, status]);
 
   useEffect(() => {
     //store the updated conversation in localstorage whenever messages are updated


### PR DESCRIPTION
- Fixed the scroll issue.
- The scrolling functionality was failing when the latest message sent by user failed to get a response. The error text "Failed to get response." and the Retry link was hidden below since the scrolling failed.  

https://github.com/Simhanischal/Mini-ChatGPT/assets/43102381/bbc5e928-0643-41b2-82a7-bd05588eb0f4